### PR TITLE
Refactor: 글 작성 반환 값 변환

### DIFF
--- a/src/main/java/com/grapefruitade/honeypost/domain/post/controller/PostController.java
+++ b/src/main/java/com/grapefruitade/honeypost/domain/post/controller/PostController.java
@@ -27,9 +27,8 @@ public class PostController {
     private final UserUtil userUtil;
 
     @PostMapping(value = "/write")
-    public ResponseEntity<String> write(@RequestBody WritePost write) {
-        postService.writePost(write, userUtil.currentUser());
-        return ResponseEntity.status(HttpStatus.OK).body("글 작성이 완료되었습니다.");
+    public ResponseEntity<Long> write(@RequestBody WritePost write) {
+        return ResponseEntity.status(HttpStatus.OK).body(postService.writePost(write, userUtil.currentUser()));
     }
 
     @PostMapping(value = "/preview", consumes = {"multipart/form-data"})

--- a/src/main/java/com/grapefruitade/honeypost/domain/post/service/PostService.java
+++ b/src/main/java/com/grapefruitade/honeypost/domain/post/service/PostService.java
@@ -35,7 +35,7 @@ public class PostService {
     private final CommonUtil commonUtil;
 
     @Transactional(rollbackFor = {Exception.class})
-    public void writePost(WritePost writePost, User user) {
+    public Long writePost(WritePost writePost, User user) {
         Post post = Post.builder()
                 .title(writePost.getTitle())
                 .content(writePost.getContent())
@@ -46,6 +46,8 @@ public class PostService {
                 .build();
 
         postRepository.save(post);
+
+        return post.getId();
     }
 
     @Transactional(rollbackFor = {Exception.class})


### PR DESCRIPTION
## 개요
프론트에서 썸네일 삽입하기 위해 글의 id가 필요해 반환값을 변경했습니다

### 작업내용
글 작성했을 때 반환값을 `글 작성이 완료되었습니다`에서 `작성한 글의 id`로 변경했습니다

![image](https://github.com/Team-Ampersand/HoneyPot-Server/assets/132069501/f0da48db-de27-48d8-84d3-5033bbb29319)

